### PR TITLE
0 MPH Speed Limit Fix

### DIFF
--- a/SpeederSettings.json
+++ b/SpeederSettings.json
@@ -15,17 +15,16 @@
   "DiscordStatusChannel": 0,
   "DispatcherCommsPath": "F:\\Games\\Run8\\DispatcherComms.dll",
   "VerboseLogging": true,
-
+  
   "Messages": {
     "ConnectedMsg": "[{stamp}] Run8 instance detected. Waiting on 'Allow External DS'",
     "DisconnectedMsg": "[{stamp}] Disconnected from Run8.",
     "SpeedingStartMsg": "[{sim_now}] {train.EngineerName}, {train.TrainSymbol}, {train_id} began speeding: block {train.BlockID}, {current:.1f}/{limit:.1f} MPH.",
     "SpeedingEndMsg": "[{sim_now}] {train.EngineerName}, {train.TrainSymbol}, {train_id} is no longer speeding: block {train.BlockID}, duration {duration:.1f} minutes, speed limit exceeded by {max_over:.1f} MPH at peak.",
     "OvrSpeedBanMsg": "[{sim_now}] {train.EngineerName}, {train.TrainSymbol} {train_id} needs to be banned for speeding >= {over:.1f} MPH over limit ({current:.1f}/{limit:.1f}) in block {train.BlockID}.",
-    "SustSpeedBanMsg": "[{sim_now}] {train.EngineerName}, {train.TrainSymbol} {train_id} needs to be banned for sustained speeding ({minutes:.1f} minutes above the limit) in block {train.BlockID}, max speed {max_over:.1f} MPH over limit.",
+    "SustSpeedBanMsg": "[{sim_now}] {train.EngineerName}, {train.TrainSymbol}, {train_id}, has been speeding for >= {minutes} minutes - currently {current:.1f}/{limit:.1f} in block {train.BlockID}.",
     "CoupledMsg": "[{sim_now}] {train.EngineerName}, {train.TrainSymbol} coupled at {speed:.1f} MPH ",
     "TrainTimeoutMsg": "[{sim_now}] Player train {train_id} no longer reporting data.",
-
     "RelinquishMsg": "[{sim_now}] {train.EngineerName} relinquished control of {train.TrainSymbol}.",
     "TookControlMsg": "[{sim_now}] {train.EngineerName} took control of {train.TrainSymbol}, Loco: {train.RailroadInitials} {train.LocoNumber}, TrainID: {train.TrainID}",
     "AutomatedNoticeMsg": "This is an automated message.",


### PR DESCRIPTION
The 0mph speed limit message was being sent too frequently. updated the logic by tracking the HP/T of the consist. 

Also fixed a few bugs in the config file, like missing coupleMsg and sustained speeding message.